### PR TITLE
Fix Download Transactions example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To download transactions:
 
 ```ts
 const downloader = db.download({
-  rpc: "<Valid RPC URL goes here>",
+  endpoint: "<Valid RPC URL goes here>",
   account: "<Valid Solana Wallet Address goes here>",
 });
 ```


### PR DESCRIPTION
In the README file, in the Download Transactions section, the `rpc` parameter is no longer valid; ' endpoint` is expected instead.